### PR TITLE
show icon on “new element” wizard for formhandler again

### DIFF
--- a/Configuration/TypoScript/pageTsConfig.ts
+++ b/Configuration/TypoScript/pageTsConfig.ts
@@ -1,7 +1,7 @@
 mod.wizards.newContentElement.wizardItems.forms {
 	elements {
 		formhandler {
-			icon = ../typo3conf/ext/formhandler/ext_icon.gif
+			iconIdentifier = formhandler
 			title = Formhandler
 			description = The swiss army knife for all kinds of mailforms.
 			tt_content_defValues.CType = formhandler_pi1

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -57,3 +57,11 @@ $GLOBALS['TCA']['pages']['columns']['module']['config']['items'][] = [
     'formlogs',
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'ext_icon.gif'
 ];
+
+// REGISTER ICONS FOR USE IN BACKEND WIZARD
+$iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
+$iconRegistry->registerIcon(
+    'formhandlerElement',
+    \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
+    ['source' => 'EXT:formhandler/ext_icon.gif']
+);


### PR DESCRIPTION
I added the iconregistry for the "new element" wizard in the backend, so it shows the appropriate icon instead of the "broken image" icon.
(plz excuse the typo in the commit message ;)