### PR TITLE
Fixed TYPO3 deprecation #68074

### DIFF
--- a/Classes/Controller/Form.php
+++ b/Classes/Controller/Form.php
@@ -1414,7 +1414,7 @@ class Form extends AbstractController
             $file = $fileOptions['file'];
             if (strlen(trim($file)) > 0) {
                 $file = $this->utilityFuncs->resolveRelPathFromSiteRoot($file);
-                $pageRenderer = $GLOBALS['TSFE']->getPageRenderer();
+                $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
                 $pageRenderer->addCssFile(
                     $file,
                     $fileOptions['alternate'] ? 'alternate stylesheet' : 'stylesheet',
@@ -1441,7 +1441,7 @@ class Form extends AbstractController
             $file = $fileOptions['file'];
             if (strlen(trim($file)) > 0) {
                 $file = $this->utilityFuncs->resolveRelPathFromSiteRoot($file);
-                $pageRenderer = $GLOBALS['TSFE']->getPageRenderer();
+                $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
                 $pageRenderer->addJsFile(
                     $file,
                     $fileOptions['type'] ? $fileOptions['type'] : 'text/javascript',
@@ -1466,7 +1466,7 @@ class Form extends AbstractController
             $file = $fileOptions['file'];
             if (strlen(trim($file)) > 0) {
                 $file = $this->utilityFuncs->resolveRelPathFromSiteRoot($file);
-                $pageRenderer = $GLOBALS['TSFE']->getPageRenderer();
+                $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
                 $pageRenderer->addJsFooterFile(
                     $file,
                     $fileOptions['type'] ? $fileOptions['type'] : 'text/javascript',


### PR DESCRIPTION
 Replaced getPageRenderer methods by shared TYPO3 PageRenderer singleton
See https://wiki.typo3.org/TYPO3.CMS/Releases/7.4/Deprecation#Deprecation:_.2368074_-_Deprecate_getPageRenderer.28.29_methods