### PR TITLE
Fixed 'pidInList' removing in the LoadDB query

### DIFF
--- a/Classes/PreProcessor/LoadDB.php
+++ b/Classes/PreProcessor/LoadDB.php
@@ -238,9 +238,11 @@ class LoadDB extends AbstractPreProcessor
         }
         $queryParts = $this->globals->getCObj()->getQuery($table, $conf, true);
 
+        // possible quotes: empty, ", ` or '
+        $quotes = '|\"|\`|\'';
         //if pidInList is not set in TypoScript remove it from the where clause.
         if (!isset($conf['pidInList']) || strlen($conf['pidInList']) === 0) {
-            $queryParts['WHERE'] = preg_replace('/([^ ]+\.pid IN \([^ ]+\) AND )/i', '', $queryParts['WHERE']);
+            $queryParts['WHERE'] = preg_replace('/([^ ]+\.('.$quotes.')pid('.$quotes.') IN \([^ ]+\) AND )/i', '', $queryParts['WHERE']);
         }
         return $GLOBALS['TYPO3_DB']->exec_SELECT_queryArray($queryParts);
     }


### PR DESCRIPTION
* The $queryParts out of cObj Query are quoted by default
* Because of this quotes, the preg_replace() pid removal if no pid is set isn't working
* Added quotes to preg_replace method to avoid wrong results