### PR TITLE
Replace obsolete loadCachedTca()call with initTCA()

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -839,8 +839,9 @@ class GeneralUtility implements SingletonInterface
         $GLOBALS['TSFE']->fe_user->fetchGroupData();
 
         // Include the TCA
-        \TYPO3\CMS\Core\Core\Bootstrap::getInstance()->loadCachedTca();
-
+        //\TYPO3\CMS\Core\Core\Bootstrap::getInstance()->loadCachedTca();
+        \TYPO3\CMS\Frontend\Utility\EidUtility::initTCA(); 
+        
         // Get the page
         $GLOBALS['TSFE']->fetch_the_id();
         $GLOBALS['TSFE']->getConfigArray();


### PR DESCRIPTION
In case the form should be validated with ajax the obsolete loadCachedTca() method is called.

This PR solves this issue and replaces loadCachedTca()call with initTCA()

Tested with TYPO3 8.7.9