### PR TITLE
Change Float class name to ValidFloat to maintain PHP7 compatibility

### DIFF
--- a/Classes/Validator/ErrorCheck/ValidFloat.php
+++ b/Classes/Validator/ErrorCheck/ValidFloat.php
@@ -17,7 +17,7 @@ namespace Typoheads\Formhandler\Validator\ErrorCheck;
 /**
  * Validates that a specified field is a valid float
  */
-class Float extends AbstractErrorCheck
+class ValidFloat extends AbstractErrorCheck
 {
     public function check()
     {


### PR DESCRIPTION
http://php.net/manual/en/reserved.other-reserved-words.php

Float is reserved word, so when you use Float validator, PHP7 throws error.