### PR TITLE
[TASK] Add "renderType" to Flexform "select" field

### DIFF
--- a/Configuration/FlexForms/flexform_ds.xml
+++ b/Configuration/FlexForms/flexform_ds.xml
@@ -53,6 +53,7 @@
                             </label>
                             <config>
                                 <type>select</type>
+                                <renderType>selectSingle</renderType>
                                 <itemsProcFunc>Typoheads\Formhandler\Utility\TcaUtility->addFields_predefined</itemsProcFunc>
                                 <maxitems>1</maxitems>
                                 <size>1</size>


### PR DESCRIPTION
Using select fields without the "renderType" setting is deprecated.