### PR TITLE
[BUGFIX] Replace ContentObjectRenderer::IMAGE()

### DIFF
--- a/Classes/View/Form.php
+++ b/Classes/View/Form.php
@@ -917,7 +917,7 @@ class Form extends AbstractView
             $imgConf['image.']['file.']['width'] = '100m';
             $imgConf['image.']['file.']['height'] = '100m';
         }
-        $thumb = $this->cObj->IMAGE($imgConf['image.']);
+        $thumb = $this->cObj->cObjGetSingle('IMAGE', $imgConf['image.']);
         return $thumb;
     }
 


### PR DESCRIPTION
This method was deprecated in TYPO3v7 and dropped in TYPO3v8.

Fixes #30