### PR TITLE
Fix call to undefined method

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -839,7 +839,7 @@ class GeneralUtility implements SingletonInterface
         $GLOBALS['TSFE']->fe_user->fetchGroupData();
 
         // Include the TCA
-        \TYPO3\CMS\Core\Core\Bootstrap::getInstance()->loadCachedTca();
+        \TYPO3\CMS\Frontend\Utility\EidUtility::initTCA();
 
         // Get the page
         $GLOBALS['TSFE']->fetch_the_id();


### PR DESCRIPTION
Fix call to undefined method TYPO3\CMS\Core\Core\Bootstrap::loadCachedTca().