### PR TITLE
[BUGFIX] fix count parameter initialization for PHP 7.2

### DIFF
--- a/Classes/View/Form.php
+++ b/Classes/View/Form.php
@@ -763,7 +763,12 @@ class Form extends AbstractView
                                                 $maxCount = $fieldSettings['errorCheck.'][$key . '.']['maxCount'];
                                                 $markers['###' . $replacedFieldname . '_maxCount###'] = $maxCount;
 
-                                                $fileCount = count($sessionFiles[$replacedFieldname]);
+                                                if (is_array($sessionFiles[$replacedFieldname])) {
+                                                    $fileCount = count($sessionFiles[$replacedFieldname]);
+                                                }
+                                                else {
+                                                    $fileCount = 0;
+                                                }
                                                 $markers['###' . $replacedFieldname . '_fileCount###'] = $fileCount;
 
                                                 $remaining = $maxCount - $fileCount;


### PR DESCRIPTION
This patch fixes this PHP 7.2 compatibility issue:

```
PHP Warning: count(): Parameter must be an array or an object that implements Countable in /home/www/html-data/web/typo3conf/ext/formhandler/Classes/View/Form.php line 766
File: /home/www/html-data/vendor/typo3/cms/typo3/sysext/core/Classes/Error/ErrorHandler.php(107)

#0 [internal function]: TYPO3\CMS\Core\Error\ErrorHandler->handleError(2, 'count(): Parame...', '/home/www/html-...', 766, Array) 
#1 /home/www/html-data/web/typo3conf/ext/formhandler/Classes/View/Form.php(766): count(NULL) 
#2 /home/www/html-data/web/typo3conf/ext/formhandler/Classes/View/Form.php(612): Typoheads\Formhandler\View\Form->fillFileMarkers(Array) 
#3 /home/www/html-data/web/typo3conf/ext/formhandler/Classes/View/Form.php(109): Typoheads\Formhandler\View\Form->fillDefaultMarkers() 
#4 /home/www/html-data/web/typo3conf/ext/formhandler/Classes/Controller/Form.php(585): Typoheads\Formhandler\View\Form->render(Array, NULL) 
#5 /home/www/html-data/web/typo3conf/ext/formhandler/Classes/Controller/Form.php(147): Typoheads\Formhandler\Controller\Form->processNotSubmitted() 
#6 /home/www/html-data/web/typo3conf/ext/formhandler/Classes/Controller/Dispatcher.php(114): Typoheads\Formhandler\Controller\Form->process() 
#7 /home/www/html-data/web/typo3conf/ext/formhandler/pi1/class.tx_formhandler_pi1.php(46): Typoheads\Formhandler\Controller\Dispatcher->main('', Array) 
#8 [internal function]: tx_formhandler_pi1->main('', Array) 
#9 /home/www/html-data/vendor/typo3/cms/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php(6341): call_user_func_array(Array, Array) 
#10 /home/www/html-data/vendor/typo3/cms/typo3/sysext/frontend/Classes/ContentObject/UserContentObject.php(41): TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer->callUserFunction('tx_formhandler_...', Array, '') 
```

Relates to: #24 