### PR TITLE
[BUGFIX] check if addQueryStringMethod is set

### DIFF
--- a/Classes/ViewHelpers/Widget/UriViewHelper.php
+++ b/Classes/ViewHelpers/Widget/UriViewHelper.php
@@ -53,14 +53,20 @@ class UriViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Widget\UriViewHelper
             ]
         ];
         $queryParameters = array_merge($queryParameters, $additionalParams);
-        return $uriBuilder->reset()
+        $uriBuilder = $uriBuilder->reset()
             ->setArguments($queryParameters)
             ->setSection($arguments['section'])
             ->setUseCacheHash($arguments['useCacheHash'])
             ->setAddQueryString(true)
-            ->setAddQueryStringMethod($arguments['addQueryStringMethod'])
             ->setArgumentsToBeExcludedFromQueryString([$argumentPrefix, 'cHash'])
             ->setFormat($arguments['format'])
-            ->build();
+        ;
+
+        $addQueryStringMethod = $arguments['addQueryStringMethod'] ?? null;
+        if (is_string($addQueryStringMethod)) {
+            $uriBuilder->setAddQueryStringMethod($addQueryStringMethod);
+        }
+
+        return $uriBuilder->build();
     }
 }


### PR DESCRIPTION
I just copied the setup from the base ViewHelper to ensure the value is checked. Otherwise it throws an exception since it could be null (and it is null)