### PR TITLE
[BUGFIX] Remove invalid namespace from language file

### DIFF
--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file t3:id="1636740703" source-language="en" target-language="de" datatype="plaintext" original="messages" date="2021-11-12T18:11:43Z" product-name="formhandler">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2021-11-12T18:11:43Z" product-name="formhandler">
 		<header/>
 		<body>
 			<trans-unit id="wizard_pi1.title" resname="wizard_pi1.title"  approved="yes">


### PR DESCRIPTION
Languagefile `Resources/Private/Language/de.locallang_db.xlf`
contained invalid xml namespace `t3:id=""`, which fails with
TYPO3v11.

This change removes the invalid argument from the language file.
